### PR TITLE
Fix(actions): Correctly deploy built site to gh-pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,14 @@ jobs:
       - name: Build the site
         run: bundle exec jekyll build
 
+      - name: Verify Build Output
+        run: ls -R ./_site
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+          force_orphan: true
           # If you are deploying to a custom domain, add it here
           # cname: example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Jekyll sites
+_site
+.sass-cache
+.jekyll-cache
+.jekyll-metadata
+
+# Bundler
+vendor/bundle
+
+# Logs
+jekyll_output.log
+
+# OS-generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
The GitHub Actions workflow was previously deploying the entire source code repository to the `gh-pages` branch instead of the statically generated site from the `_site` directory.

This commit corrects the workflow by:
- Adding `force_orphan: true` to the `peaceiris/actions-gh-pages` step. This ensures the target branch is completely clean before each deployment, preventing old or incorrect files from persisting.
- Adding a standard `.gitignore` file for Jekyll projects. This prevents build artifacts, dependency caches (`vendor/bundle`), and other local files from being tracked by Git, improving the repository's health.