### PR TITLE
Fix: Correct deployment paths and workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
@@ -21,10 +24,14 @@ jobs:
       - name: Build the site
         run: bundle exec jekyll build
 
+      - name: Verify Build Output
+        run: ls -R ./_site
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+          force_orphan: true
           # If you are deploying to a custom domain, add it here
           # cname: example.com

--- a/_config.yml
+++ b/_config.yml
@@ -24,8 +24,8 @@ author:
   email: your-email@domain.com
 description: >- # this means to ignore newlines until "baseurl:"
   A minimal blog about technology, tutorials, and thoughts.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/Google_Jules_example" # the subpath of your site, e.g. /blog
+url: "https://mitsugeek.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Social links
 twitter_username: your-twitter-username


### PR DESCRIPTION
This commit provides a comprehensive fix for two separate issues that were preventing the Jekyll site from deploying and rendering correctly on GitHub Pages.

1.  **Fix Asset/Link Paths for Subdirectory:**
    - Updates `_config.yml` by setting `baseurl` to `/Google_Jules_example` and `url` to `https://mitsugeek.github.io`. This allows Jekyll to generate correct URLs for CSS, JS, and internal links, resolving the 404 errors for assets and broken navigation.

2.  **Fix Workflow Permissions:**
    - Updates `.github/workflows/main.yml` to include `permissions: contents: write`. This grants the workflow the necessary permissions to push to the `gh-pages` branch, resolving the 403 Forbidden error.
    - This also re-applies previous workflow enhancements like `force_orphan: true` and a build verification step.

This combined fix should result in a successful and correctly rendered deployment.