### PR TITLE
fix: GitHub Actionsのビルド設定を修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           bundler-cache: true # Automatically runs bundle install
 
       - name: Build the site
-        run: bundle exec jekyll build
+        run: bundle exec jekyll build --baseurl "/${{ github.event.repository.name }}"
 
       - name: Verify Build Output
         run: ls -R ./_site


### PR DESCRIPTION
GitHub ActionsのワークフローでJekyllをビルドする際に、`baseurl`の指定が誤っていたため、デプロイされたサイトで404エラーが発生していました。

`bundle exec jekyll build` コマンドの `--baseurl` オプションに渡す値の先頭に `/` を追加し、正しいURLが生成されるように修正しました。